### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Logs
+.ipynb_checkpoints
+
+# OS generated files
+.DS_Store
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
Hi @Thomas-Moore-Creative,

Here's a starting .gitignore doc in response to [issue 11](https://github.com/oceanhackweek/ohw21-proj-cmip-ard/issues/11). 

As an aside, I took a look at this example gitignore as well: https://gist.github.com/octocat/9257657, but it didn't seem like there was any license attached to it. It seems like GitHub would want this to be used freely, but without a license such as CC0, I suppose we wouldn't be able to use (copy/paste) it, correct?

Thanks,

Andrew