### PR TITLE
Adding Regridding

### DIFF
--- a/CMIP6-ard.ipynb
+++ b/CMIP6-ard.ipynb
@@ -887,6 +887,772 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c8d349a7-1a7f-4605-b720-21b9884bcee3",
+   "metadata": {},
+   "source": [
+    "# Regridding for comparison between models\n",
+    "\n",
+    "The different models (`source_id`s) will often use different grids.  This can make comparing between models tricky.  To deal with that you can use the either the `interpolate_grid_label()` function of `cmip6_preprocessing` or the `xesmf` library.\n",
+    "\n",
+    "To get started let's grab two datasets with different grid types and preprocess them to get setup.  These are the same steps we ran in the previous example to get setup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bdc22fd6-ecb7-40ff-ad1c-b810dc6eee89",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--> The keys in the returned dictionary of datasets are constructed as follows:\n",
+      "\t'activity_id.institution_id.source_id.experiment_id.member_id.table_id.variable_id.grid_label.zstore.dcpp_init_year.version'\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div>\n",
+       "        <style>\n",
+       "            /* Turns off some styling */\n",
+       "            progress {\n",
+       "                /* gets rid of default border in Firefox and Opera. */\n",
+       "                border: none;\n",
+       "                /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
+       "                background-size: auto;\n",
+       "            }\n",
+       "            .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
+       "                background: #F44336;\n",
+       "            }\n",
+       "        </style>\n",
+       "      <progress value='4' class='' max='4' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
+       "      100.00% [4/4 00:00<00:00]\n",
+       "    </div>\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cat_regrid = col.search(\n",
+    "    variable_id=[\"tos\", \"o2\"],\n",
+    "    experiment_id=[\"historical\"],\n",
+    "    source_id=['ACCESS-CM2', 'GFDL-CM4'],\n",
+    "    table_id=[\"Omon\"],\n",
+    "    member_id = ['r1i1p1f1']\n",
+    ")\n",
+    "ddict_regrid = cat_regrid.to_dataset_dict(\n",
+    "    zarr_kwargs={\"consolidated\": True, \"use_cftime\": True},\n",
+    "    aggregate=False,\n",
+    "    preprocess=combined_preprocessing,\n",
+    ")\n",
+    "ddict_regrid = merge_variables(ddict_regrid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0d98490b-107c-4dd3-ba4f-8e2d10aded24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove the `variable_id` attr manually\n",
+    "ddict_combined_aa = {k:maybe_remove_attrs(ds, 'variable_id') for k,ds in ddict_regrid.items()}\n",
+    "ddict_combined_b = concat_experiments(ddict_combined_aa)\n",
+    "\n",
+    "# same thing for experiment_id\n",
+    "ddict_combined_bb = {k:maybe_remove_attrs(ds, 'experiment_id') for k,ds in ddict_combined_b.items()}\n",
+    "ddict_combined = concat_members(ddict_combined_bb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e819ff80-fef6-4066-b5cc-18b4cf09ab52",
+   "metadata": {},
+   "source": [
+    "## Match a model grid to the grid of another model\n",
+    "\n",
+    "`grid_label` is stored as a global attribute on CMIP6 models.  We can see the different grid labels of our datasets by looping through our `ddict_regrid` dict:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6bf417e9-e2a2-4af7-9b52-f9aad7246054",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GFDL-CM4.gr.historical.Omon.r1i1p1f1 has grid type: gr\n",
+      "ACCESS-CM2.gn.historical.Omon.r1i1p1f1 has grid type: gn\n",
+      "GFDL-CM4.gn.historical.Omon.r1i1p1f1 has grid type: gn\n"
+     ]
+    }
+   ],
+   "source": [
+    "for key, ds in ddict_regrid.items():\n",
+    "    print(key, 'has grid type:', ds.attrs['grid_label'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2902bd31-06cf-47e8-abd5-61d14f7097e5",
+   "metadata": {},
+   "source": [
+    "We see that the `ACCESS-CM2` model and one of the `GFDL-CM4` models as the `gn` grid type while the other `GFDL-CM4` model as the `gr` grid type.  To convert the `gr` grid type to `gn` we use the `interpolate_grid_label` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f25ea91f-e8bf-4159-854a-3e6584b46b0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cmip6_preprocessing.postprocessing import interpolate_grid_label"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1fc67fbd-34f8-496b-a5e0-385d60ddc238",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_grids_dict = interpolate_grid_label(ddict_combined, target_grid_label='gn')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70f07dbf-026d-43a2-8de6-8f7712792af3",
+   "metadata": {},
+   "source": [
+    "We see our output dictionary now only has two items instead of three: one item with the same ACCESS-CM2 model and other item with the combined GFDL-CM4 model datasets on a `gn` grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "36d3370b-6221-42e4-87ad-7290b505c01b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GFDL-CM4.Omon.r1i1p1f1 has grid type: gn\n",
+      "ACCESS-CM2.Omon.r1i1p1f1 has grid type: gn\n"
+     ]
+    }
+   ],
+   "source": [
+    "for key, ds in combined_grids_dict.items():\n",
+    "    print(key, 'has grid type:', ds.attrs['grid_label'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "178b3924-2f84-4878-9145-64b218a9f1bd",
+   "metadata": {},
+   "source": [
+    "## Regrid to an arbitrary grid\n",
+    "\n",
+    "We have gotten our grids into the same type, which is a solid step.  Let's say that instead we want to align our grids together on some arbirtary grids.  To do this we could use the `xesmf` library to define our custom grids and apply them to the datasets."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "048d7ed7-a0b8-4f3e-9e9a-e15b50affa42",
+   "metadata": {},
+   "source": [
+    "### Noting of the current grid resolutions\n",
+    "\n",
+    "Since we are only working with two models let's pull them each out into their own dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6872da67-62c8-4a5d-9cac-dd7456bd2ead",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "access_cm2 = combined_grids_dict['ACCESS-CM2.Omon.r1i1p1f1']\n",
+    "gfdl_cm4 = combined_grids_dict['GFDL-CM4.Omon.r1i1p1f1']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "350a1366-5299-44f0-b1e3-ed4707b6cfa2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ACCESS-CM2 x and y grids:\n",
+      "latitudes [-77.87662506 -77.87662506 -77.87662506 -77.87662506 -77.87662506\n",
+      " -77.87662506 -77.87662506 -77.87662506 -77.87662506 -77.87662506]\n",
+      "longitudes [80.5 81.5 82.5 83.5 84.5 85.5 86.5 87.5 88.5 89.5]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('ACCESS-CM2 x and y grids:')\n",
+    "print('latitudes', access_cm2.lat.values[0, :10])\n",
+    "print('longitudes', access_cm2.lon.values[0, :10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9701fe3f-72af-4b7b-a33f-d281ff5d90d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GFDL-CM4 x and y grids:\n",
+      "latitudes [-79.80674  -79.80527  -79.80382  -79.802376 -79.80096  -79.79955\n",
+      " -79.79817  -79.79681  -79.795456 -79.79412 ]\n",
+      "longitudes [60.281647 60.529633 60.777588 61.025574 61.27356  61.521515 61.7695\n",
+      " 62.017487 62.265472 62.51346 ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('GFDL-CM4 x and y grids:')\n",
+    "print('latitudes', gfdl_cm4.lat.values[0, :10])\n",
+    "print('longitudes', gfdl_cm4.lon.values[0, :10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f516e13-7689-40ae-b50d-b50393c9ac53",
+   "metadata": {},
+   "source": [
+    "Looking at the output we can see the differing values and resolutions of the latitudesa and longitudes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9357a61-8756-4fc9-9a7b-b9356ba30cec",
+   "metadata": {},
+   "source": [
+    "### Creating the new grid\n",
+    "\n",
+    "To create our new grid we will:\n",
+    "1. Define our new grid as a dataset with `lat` and `lon`\n",
+    "2. Use the `xesmf` library to create a `regridder` object\n",
+    "3. Convert our model datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "192aef85-4592-4d28-b1df-81a2a21ef34b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import numpy as np\n",
+    "import xesmf as xe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2eee1a2c-2bb8-450d-a776-3f919344c6ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><svg style=\"position: absolute; width: 0; height: 0; overflow: hidden\">\n",
+       "<defs>\n",
+       "<symbol id=\"icon-database\" viewBox=\"0 0 32 32\">\n",
+       "<path d=\"M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z\"></path>\n",
+       "<path d=\"M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z\"></path>\n",
+       "<path d=\"M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z\"></path>\n",
+       "</symbol>\n",
+       "<symbol id=\"icon-file-text2\" viewBox=\"0 0 32 32\">\n",
+       "<path d=\"M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z\"></path>\n",
+       "<path d=\"M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "<path d=\"M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "<path d=\"M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "</symbol>\n",
+       "</defs>\n",
+       "</svg>\n",
+       "<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.\n",
+       " *\n",
+       " */\n",
+       "\n",
+       ":root {\n",
+       "  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));\n",
+       "  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));\n",
+       "  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));\n",
+       "  --xr-border-color: var(--jp-border-color2, #e0e0e0);\n",
+       "  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);\n",
+       "  --xr-background-color: var(--jp-layout-color0, white);\n",
+       "  --xr-background-color-row-even: var(--jp-layout-color1, white);\n",
+       "  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);\n",
+       "}\n",
+       "\n",
+       "html[theme=dark],\n",
+       "body.vscode-dark {\n",
+       "  --xr-font-color0: rgba(255, 255, 255, 1);\n",
+       "  --xr-font-color2: rgba(255, 255, 255, 0.54);\n",
+       "  --xr-font-color3: rgba(255, 255, 255, 0.38);\n",
+       "  --xr-border-color: #1F1F1F;\n",
+       "  --xr-disabled-color: #515151;\n",
+       "  --xr-background-color: #111111;\n",
+       "  --xr-background-color-row-even: #111111;\n",
+       "  --xr-background-color-row-odd: #313131;\n",
+       "}\n",
+       "\n",
+       ".xr-wrap {\n",
+       "  display: block;\n",
+       "  min-width: 300px;\n",
+       "  max-width: 700px;\n",
+       "}\n",
+       "\n",
+       ".xr-text-repr-fallback {\n",
+       "  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-header {\n",
+       "  padding-top: 6px;\n",
+       "  padding-bottom: 6px;\n",
+       "  margin-bottom: 4px;\n",
+       "  border-bottom: solid 1px var(--xr-border-color);\n",
+       "}\n",
+       "\n",
+       ".xr-header > div,\n",
+       ".xr-header > ul {\n",
+       "  display: inline;\n",
+       "  margin-top: 0;\n",
+       "  margin-bottom: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-obj-type,\n",
+       ".xr-array-name {\n",
+       "  margin-left: 2px;\n",
+       "  margin-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-obj-type {\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-sections {\n",
+       "  padding-left: 0 !important;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 150px auto auto 1fr 20px 20px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input + label {\n",
+       "  color: var(--xr-disabled-color);\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:enabled + label {\n",
+       "  cursor: pointer;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:enabled + label:hover {\n",
+       "  color: var(--xr-font-color0);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary {\n",
+       "  grid-column: 1;\n",
+       "  color: var(--xr-font-color2);\n",
+       "  font-weight: 500;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary > span {\n",
+       "  display: inline-block;\n",
+       "  padding-left: 0.5em;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:disabled + label {\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in + label:before {\n",
+       "  display: inline-block;\n",
+       "  content: '►';\n",
+       "  font-size: 11px;\n",
+       "  width: 15px;\n",
+       "  text-align: center;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:disabled + label:before {\n",
+       "  color: var(--xr-disabled-color);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked + label:before {\n",
+       "  content: '▼';\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked + label > span {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary,\n",
+       ".xr-section-inline-details {\n",
+       "  padding-top: 4px;\n",
+       "  padding-bottom: 4px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-inline-details {\n",
+       "  grid-column: 2 / -1;\n",
+       "}\n",
+       "\n",
+       ".xr-section-details {\n",
+       "  display: none;\n",
+       "  grid-column: 1 / -1;\n",
+       "  margin-bottom: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked ~ .xr-section-details {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-array-wrap {\n",
+       "  grid-column: 1 / -1;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 20px auto;\n",
+       "}\n",
+       "\n",
+       ".xr-array-wrap > label {\n",
+       "  grid-column: 1;\n",
+       "  vertical-align: top;\n",
+       "}\n",
+       "\n",
+       ".xr-preview {\n",
+       "  color: var(--xr-font-color3);\n",
+       "}\n",
+       "\n",
+       ".xr-array-preview,\n",
+       ".xr-array-data {\n",
+       "  padding: 0 5px !important;\n",
+       "  grid-column: 2;\n",
+       "}\n",
+       "\n",
+       ".xr-array-data,\n",
+       ".xr-array-in:checked ~ .xr-array-preview {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-array-in:checked ~ .xr-array-data,\n",
+       ".xr-array-preview {\n",
+       "  display: inline-block;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list {\n",
+       "  display: inline-block !important;\n",
+       "  list-style: none;\n",
+       "  padding: 0 !important;\n",
+       "  margin: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list li {\n",
+       "  display: inline-block;\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list:before {\n",
+       "  content: '(';\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list:after {\n",
+       "  content: ')';\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list li:not(:last-child):after {\n",
+       "  content: ',';\n",
+       "  padding-right: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-has-index {\n",
+       "  font-weight: bold;\n",
+       "}\n",
+       "\n",
+       ".xr-var-list,\n",
+       ".xr-var-item {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-var-item > div,\n",
+       ".xr-var-item label,\n",
+       ".xr-var-item > .xr-var-name span {\n",
+       "  background-color: var(--xr-background-color-row-even);\n",
+       "  margin-bottom: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-var-item > .xr-var-name:hover span {\n",
+       "  padding-right: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-list > li:nth-child(odd) > div,\n",
+       ".xr-var-list > li:nth-child(odd) > label,\n",
+       ".xr-var-list > li:nth-child(odd) > .xr-var-name span {\n",
+       "  background-color: var(--xr-background-color-row-odd);\n",
+       "}\n",
+       "\n",
+       ".xr-var-name {\n",
+       "  grid-column: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-var-dims {\n",
+       "  grid-column: 2;\n",
+       "}\n",
+       "\n",
+       ".xr-var-dtype {\n",
+       "  grid-column: 3;\n",
+       "  text-align: right;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-var-preview {\n",
+       "  grid-column: 4;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name,\n",
+       ".xr-var-dims,\n",
+       ".xr-var-dtype,\n",
+       ".xr-preview,\n",
+       ".xr-attrs dt {\n",
+       "  white-space: nowrap;\n",
+       "  overflow: hidden;\n",
+       "  text-overflow: ellipsis;\n",
+       "  padding-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name:hover,\n",
+       ".xr-var-dims:hover,\n",
+       ".xr-var-dtype:hover,\n",
+       ".xr-attrs dt:hover {\n",
+       "  overflow: visible;\n",
+       "  width: auto;\n",
+       "  z-index: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs,\n",
+       ".xr-var-data {\n",
+       "  display: none;\n",
+       "  background-color: var(--xr-background-color) !important;\n",
+       "  padding-bottom: 5px !important;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs-in:checked ~ .xr-var-attrs,\n",
+       ".xr-var-data-in:checked ~ .xr-var-data {\n",
+       "  display: block;\n",
+       "}\n",
+       "\n",
+       ".xr-var-data > table {\n",
+       "  float: right;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name span,\n",
+       ".xr-var-data,\n",
+       ".xr-attrs {\n",
+       "  padding-left: 25px !important;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs,\n",
+       ".xr-var-attrs,\n",
+       ".xr-var-data {\n",
+       "  grid-column: 1 / -1;\n",
+       "}\n",
+       "\n",
+       "dl.xr-attrs {\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 125px auto;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt,\n",
+       ".xr-attrs dd {\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "  float: left;\n",
+       "  padding-right: 10px;\n",
+       "  width: auto;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt {\n",
+       "  font-weight: normal;\n",
+       "  grid-column: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt:hover span {\n",
+       "  display: inline-block;\n",
+       "  background: var(--xr-background-color);\n",
+       "  padding-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dd {\n",
+       "  grid-column: 2;\n",
+       "  white-space: pre-wrap;\n",
+       "  word-break: break-all;\n",
+       "}\n",
+       "\n",
+       ".xr-icon-database,\n",
+       ".xr-icon-file-text2 {\n",
+       "  display: inline-block;\n",
+       "  vertical-align: middle;\n",
+       "  width: 1em;\n",
+       "  height: 1.5em !important;\n",
+       "  stroke-width: 0;\n",
+       "  stroke: currentColor;\n",
+       "  fill: currentColor;\n",
+       "}\n",
+       "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:  (lat: 360, lon: 480)\n",
+       "Coordinates:\n",
+       "  * lat      (lat) float64 -90.0 -89.5 -89.0 -88.5 -88.0 ... 88.0 88.5 89.0 89.5\n",
+       "  * lon      (lon) float64 -180.0 -179.2 -178.5 -177.8 ... 177.8 178.5 179.2\n",
+       "Data variables:\n",
+       "    *empty*</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-bca92486-162d-47e2-acc3-0dfe4e481bdc' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-bca92486-162d-47e2-acc3-0dfe4e481bdc' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>lat</span>: 360</li><li><span class='xr-has-index'>lon</span>: 480</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-9d44f26f-41cd-47a4-aedb-3f020e297add' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9d44f26f-41cd-47a4-aedb-3f020e297add' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-90.0 -89.5 -89.0 ... 89.0 89.5</div><input id='attrs-fea000d5-e607-40cb-9f03-a94eb07016c1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fea000d5-e607-40cb-9f03-a94eb07016c1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-68a5c056-df11-4ecd-b2af-6d0105126c38' class='xr-var-data-in' type='checkbox'><label for='data-68a5c056-df11-4ecd-b2af-6d0105126c38' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-90. , -89.5, -89. , ...,  88.5,  89. ,  89.5])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-180.0 -179.2 ... 178.5 179.2</div><input id='attrs-a2cd0885-cde6-4297-8a47-e5287442df0c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a2cd0885-cde6-4297-8a47-e5287442df0c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-302aa706-d775-417d-8ad9-d058b1d5d9f8' class='xr-var-data-in' type='checkbox'><label for='data-302aa706-d775-417d-8ad9-d058b1d5d9f8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-180.  , -179.25, -178.5 , ...,  177.75,  178.5 ,  179.25])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-63f1270c-d538-432d-9a1a-741abaf06d8f' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-63f1270c-d538-432d-9a1a-741abaf06d8f' class='xr-section-summary'  title='Expand/collapse section'>Data variables: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-9fdef0b0-033e-4cdf-81b2-28901cfa9029' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-9fdef0b0-033e-4cdf-81b2-28901cfa9029' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+      ],
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:  (lat: 360, lon: 480)\n",
+       "Coordinates:\n",
+       "  * lat      (lat) float64 -90.0 -89.5 -89.0 -88.5 -88.0 ... 88.0 88.5 89.0 89.5\n",
+       "  * lon      (lon) float64 -180.0 -179.2 -178.5 -177.8 ... 177.8 178.5 179.2\n",
+       "Data variables:\n",
+       "    *empty*"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create output grids\n",
+    "ds_out = xr.Dataset({'lat': (['lat'], np.arange(-90, 90, 0.5)),\n",
+    "                     'lon': (['lon'], np.arange(-180, 180, 0.75)),\n",
+    "                    }\n",
+    "                   )\n",
+    "ds_out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81168cdd-4e7b-4fb8-95a0-5381ed7fd366",
+   "metadata": {},
+   "source": [
+    "`ds_out` now defines our target grid, or what we want the output grids to look like.  We can see from the `lat` and `lon` values in the dataset that our output latitude will be global with 0.5 degree resolution and the longitude will be global with 0.75 degree resolution.\n",
+    "\n",
+    "To create the new grids we will:\n",
+    "1. Create a `regridder` object\n",
+    "2. Use the `regridder` object to do the converting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "b70b3b4f-83eb-464e-a506-35e18d847b64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "regridder = xe.Regridder(gfdl_cm4, ds_out, 'bilinear')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "6b6a974b-0b0e-492d-b165-15074aa3e5d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "access_cm2_new_grid = regridder(access_cm2)\n",
+    "gfdl_cm4_new_grid = regridder(gfdl_cm4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70b8c08e-e5c1-4332-b4b1-d1b687385ebf",
+   "metadata": {},
+   "source": [
+    "We now have new datasets with the grid that we defined.  We can see that the latitudes and longitudes have indeed changed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "71d09185-14fa-4275-bf92-5f8ab93ab79e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ACCESS-CM2 x and y grids:\n",
+      "latitides [-90.  -89.5 -89.  -88.5 -88.  -87.5 -87.  -86.5 -86.  -85.5]\n",
+      "longitudes [-180.   -179.25 -178.5  -177.75 -177.   -176.25 -175.5  -174.75 -174.\n",
+      " -173.25]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('ACCESS-CM2 x and y grids:')\n",
+    "print('latitides', access_cm2_new_grid.lat.values[:10])\n",
+    "print('longitudes', access_cm2_new_grid.lon.values[:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "898f2ca8-c93f-4c79-8c75-0163b2206cb7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GFDL-CM4 x and y grids:\n",
+      "latitides [-90.  -89.5 -89.  -88.5 -88.  -87.5 -87.  -86.5 -86.  -85.5]\n",
+      "longitudes [-180.   -179.25 -178.5  -177.75 -177.   -176.25 -175.5  -174.75 -174.\n",
+      " -173.25]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('GFDL-CM4 x and y grids:')\n",
+    "print('latitides', gfdl_cm4_new_grid.lat.values[:10])\n",
+    "print('longitudes', gfdl_cm4_new_grid.lon.values[:10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "320f7b6f-7862-4a84-9c43-6d59e76b6f1b",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## What it is
The PR adds a regridding section to the `CMIP6-ard.ipynb` notebook.  The section is added after the first plotting/time series section but before the masking.

## How it was done
There are two parts:
1. regridding one model to another model using the built in tools in `cmip6_preprocessing`
2. regridding models to a grid the user defines using `xesmf`

To keep consistent with the notebook I used the same preprocessing steps as the first section.  I tried to use the same models as the first section as well, but it turned out they have the same grids already so a regridding example on those models would have not have been very exciting.  One idea for a future iteration would be to find a set of models where both the time series and the regridding have interesting results to provide some consistency to the notebook.

## A note on timing
I put this in the main `CMIP6-ard.ipynb` so as not to add a new notebook to the repo.  So as not to mess with the main virtual presentation I think its better to wait and merge this later today.